### PR TITLE
fixed back arrow render

### DIFF
--- a/text/user.css
+++ b/text/user.css
@@ -471,11 +471,11 @@
 .main-topBar-button:first-child:before {
     content: "<";
 }
-.main-topBar-button.main-topBar-forward::before {
+.main-topBar-button.main-topBar-responsiveForward::before {
     content: ">";
 }
 .main-topBar-button:first-child > svg,
-.main-topBar-button.main-topBar-forward > svg {
+.main-topBar-button.main-topBar-responsiveForward > svg {
     display: none;
 }
 .main-topBar-topbarContent {


### PR DESCRIPTION
changed "main-topBar-forward" to "main-topBar-responsiveForward". In the last Spotify update the back arrow wasnt showing correctly, this fixes it.